### PR TITLE
Cannot currently support wrapping for types such as Span<T> which are…

### DIFF
--- a/Present.CodeGeneration/MethodAnalyser.cs
+++ b/Present.CodeGeneration/MethodAnalyser.cs
@@ -72,19 +72,21 @@
                 return this.IsSupportedType(type.GetElementType());
             }
 
-            // All value types are supported (which also includes the void return type)
-            if (type.IsValueType)
-            {
-                return true;
-            }
-
-            // Common reference types are also supported
+            // Common reference types that cause no difficulties with mocking are supported
             if (type == typeof(string))
             {
                 return true;
             }
 
-            return false;
+            // Structures passed by reference (ref struct), such as Span<T>, are not supported
+            // even though they are value types
+            if (type.IsByRefLike)
+            {
+                return false;
+            }
+
+            // Any remaining value types are supported (which also includes the void return type)
+            return type.IsValueType;
         }
     }
 }

--- a/Present.CodeGeneration/Present.CodeGeneration.csproj
+++ b/Present.CodeGeneration/Present.CodeGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
… defined as ref struct. We can determine these with the IsByRefLike property.

Library switched to .NET Core as the IsByRefLike property on Type is not currently in .NET Standard.